### PR TITLE
Ηandle JavaScript-powered-urls from ScienceDirect.com.

### DIFF
--- a/src/main/java/eu/openaire/doc_urls_retriever/DocUrlsRetriever.java
+++ b/src/main/java/eu/openaire/doc_urls_retriever/DocUrlsRetriever.java
@@ -56,7 +56,7 @@ public class DocUrlsRetriever
     	
     	// Use testing input/output files.
 		/*try {
-			new FileUtils(new FileInputStream(new File(System.getProperty("user.dir") + "//src//main//resources//sampleCleanUrls3000.json")),
+			new FileUtils(new FileInputStream(new File(System.getProperty("user.dir") + "//src//main//resources//testRandomNewList1000.csv")),
 							new FileOutputStream(new File(System.getProperty("user.dir") + "//src//main//resources//testOutputFile.json")));
 		} catch (FileNotFoundException e) {
 			String errorMessage = "InputFile not found!";

--- a/src/main/java/eu/openaire/doc_urls_retriever/DocUrlsRetriever.java
+++ b/src/main/java/eu/openaire/doc_urls_retriever/DocUrlsRetriever.java
@@ -56,7 +56,7 @@ public class DocUrlsRetriever
     	
     	// Use testing input/output files.
 		/*try {
-			new FileUtils(new FileInputStream(new File(System.getProperty("user.dir") + "//src//main//resources//testRandomNewList1000.csv")),
+			new FileUtils(new FileInputStream(new File(System.getProperty("user.dir") + "//src//main//resources//sampleCleanUrls3000.json")),
 							new FileOutputStream(new File(System.getProperty("user.dir") + "//src//main//resources//testOutputFile.json")));
 		} catch (FileNotFoundException e) {
 			String errorMessage = "InputFile not found!";

--- a/src/main/java/eu/openaire/doc_urls_retriever/crawler/CrawlerController.java
+++ b/src/main/java/eu/openaire/doc_urls_retriever/crawler/CrawlerController.java
@@ -1,10 +1,16 @@
 package eu.openaire.doc_urls_retriever.crawler;
 
+import edu.uci.ics.crawler4j.url.URLCanonicalizer;
+import eu.openaire.doc_urls_retriever.exceptions.ConnTimeoutException;
+import eu.openaire.doc_urls_retriever.exceptions.DomainBlockedException;
+import eu.openaire.doc_urls_retriever.exceptions.DomainWithUnsupportedHEADmethodException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-//import eu.openaire.doc_urls_retriever.util.http.HttpUtils;
+import eu.openaire.doc_urls_retriever.util.http.HttpUtils;
 import eu.openaire.doc_urls_retriever.util.file.FileUtils;
 import eu.openaire.doc_urls_retriever.util.url.UrlUtils;
+
+import java.nio.charset.StandardCharsets;
 
 
 /**
@@ -15,7 +21,7 @@ public class CrawlerController
 	private static final Logger logger = LoggerFactory.getLogger(CrawlerController.class);
 	
 	public static long urlsReachedCrawler = 0;	// Potentially useful for statistics.
-	public static boolean useIdUrlPairs = false;
+	public static boolean useIdUrlPairs = true;
 	
 	
 	public CrawlerController() throws RuntimeException
@@ -28,16 +34,7 @@ public class CrawlerController
 			else
 				UrlUtils.loadAndCheckUrls();
 			
-			// Here test individual urls.
-			//String url = "http://repositorio.ipen.br:8080/xmlui/bitstream/handle/123456789/11176/09808.pdf?sequence=1&isAllowed=y";
-			//String url = "https://ris.utwente.nl/ws/portalfiles/portal/5118887";
-			//String url = "http://biblioteca.ucm.es/tesis/19972000/X/0/X0040301.pdf";
-			//String url = "http://vddb.library.lt/fedora/get/LT-eLABa-0001:E.02~2008~D_20080618_115819-91936/DS.005.0.02.ETD";
-			//String url = "http://dx.doi.org/10.1016/0042-6989(95)90089-6";
-			//String url = "https://www.sciencedirect.com/science/article/pii/S221478531500694X?via%3Dihub";
-			//String url = "https://www.sciencedirect.com/science/article/pii/S221478531500694X/pdf?md5=580457b09a692401774fe0069b8ca507&amp;pid=1-s2.0-S221478531500694X-main.pdf";
-			//String url = "https://ac.els-cdn.com/S221478531500694X/1-s2.0-S221478531500694X-main.pdf?_tid=8cce02f3-f78e-4593-9828-87b40fcb4f18&acdnat=1527114470_60086f5255bb56d2eb01950734b17fb1";
-			//HttpUtils.connectAndCheckMimeType(null, url, url, url, null, true, false);
+			//runIndividualTests();
 			
 	        // Write any remaining urls from memory to disk.
 	        if ( FileUtils.quadrupleToBeLoggedOutputList.size() > 0 ) {
@@ -49,6 +46,30 @@ public class CrawlerController
 			logger.error("", e);
 			throw new RuntimeException(e);
 		}
+	}
+	
+	
+	public static void runIndividualTests()
+			throws RuntimeException, ConnTimeoutException, DomainBlockedException, DomainWithUnsupportedHEADmethodException
+	{
+		// Here test individual urls.
+		//String url = "http://repositorio.ipen.br:8080/xmlui/bitstream/handle/123456789/11176/09808.pdf?sequence=1&isAllowed=y";
+		//String url = "https://ris.utwente.nl/ws/portalfiles/portal/5118887";
+		//String url = "http://biblioteca.ucm.es/tesis/19972000/X/0/X0040301.pdf";
+		//String url = "http://vddb.library.lt/fedora/get/LT-eLABa-0001:E.02~2008~D_20080618_115819-91936/DS.005.0.02.ETD";
+		//String url = "http://dx.doi.org/10.1016/0042-6989(95)90089-6";
+		String url = "https://www.sciencedirect.com/science/article/pii/S221478531500694X?via%3Dihub";
+		//String url = "https://www.sciencedirect.com/science/article/pii/S221478531500694X/pdf?md5=580457b09a692401774fe0069b8ca507&amp;pid=1-s2.0-S221478531500694X-main.pdf";
+		//String url = "https://jual.nipissingu.ca/wp-content/uploads/sites/25/2016/03/v10202.pdf\" rel=\"";
+		//String url = "https://ac.els-cdn.com/S221478531500694X/1-s2.0-S221478531500694X-main.pdf?_tid=8cce02f3-f78e-4593-9828-87b40fcb4f18&acdnat=1527114470_60086f5255bb56d2eb01950734b17fb1";
+		
+		String urlToCheck = null;
+		if ( (urlToCheck = URLCanonicalizer.getCanonicalURL(url, null, StandardCharsets.UTF_8)) == null ) {
+			logger.warn("Could not cannonicalize url: " + url);
+			return;
+		}
+		
+		HttpUtils.connectAndCheckMimeType(null, urlToCheck, urlToCheck, urlToCheck, null, true, false);
 	}
 	
 }

--- a/src/main/java/eu/openaire/doc_urls_retriever/crawler/CrawlerController.java
+++ b/src/main/java/eu/openaire/doc_urls_retriever/crawler/CrawlerController.java
@@ -15,7 +15,7 @@ public class CrawlerController
 	private static final Logger logger = LoggerFactory.getLogger(CrawlerController.class);
 	
 	public static long urlsReachedCrawler = 0;	// Potentially useful for statistics.
-	public static boolean useIdUrlPairs = true;
+	public static boolean useIdUrlPairs = false;
 	
 	
 	public CrawlerController() throws RuntimeException
@@ -33,8 +33,11 @@ public class CrawlerController
 			//String url = "https://ris.utwente.nl/ws/portalfiles/portal/5118887";
 			//String url = "http://biblioteca.ucm.es/tesis/19972000/X/0/X0040301.pdf";
 			//String url = "http://vddb.library.lt/fedora/get/LT-eLABa-0001:E.02~2008~D_20080618_115819-91936/DS.005.0.02.ETD";
-			/*String url = "http://dx.doi.org/10.1111/jora.12209";
-			HttpUtils.connectAndCheckMimeType(null, url, url, url, null, true, false);*/
+			//String url = "http://dx.doi.org/10.1016/0042-6989(95)90089-6";
+			//String url = "https://www.sciencedirect.com/science/article/pii/S221478531500694X?via%3Dihub";
+			//String url = "https://www.sciencedirect.com/science/article/pii/S221478531500694X/pdf?md5=580457b09a692401774fe0069b8ca507&amp;pid=1-s2.0-S221478531500694X-main.pdf";
+			//String url = "https://ac.els-cdn.com/S221478531500694X/1-s2.0-S221478531500694X-main.pdf?_tid=8cce02f3-f78e-4593-9828-87b40fcb4f18&acdnat=1527114470_60086f5255bb56d2eb01950734b17fb1";
+			//HttpUtils.connectAndCheckMimeType(null, url, url, url, null, true, false);
 			
 	        // Write any remaining urls from memory to disk.
 	        if ( FileUtils.quadrupleToBeLoggedOutputList.size() > 0 ) {

--- a/src/main/java/eu/openaire/doc_urls_retriever/util/file/FileUtils.java
+++ b/src/main/java/eu/openaire/doc_urls_retriever/util/file/FileUtils.java
@@ -36,7 +36,7 @@ public class FileUtils
 	public static int unretrievableInputLines = 0;	// For better statistics in the end.
     public static int unretrievableUrlsOnly = 0;
     public static int groupCount = 300;
-    public static int maxStoringWaitingTime = 20000;	// 20sec
+    public static int maxStoringWaitingTime = 30000;	// 30sec
 	
 	public static final List<QuadrupleToBeLogged> quadrupleToBeLoggedOutputList = new ArrayList<>();
 	

--- a/src/main/java/eu/openaire/doc_urls_retriever/util/url/UrlUtils.java
+++ b/src/main/java/eu/openaire/doc_urls_retriever/util/url/UrlUtils.java
@@ -332,12 +332,12 @@ public class UrlUtils
 			UrlUtils.logQuadruple(urlId, retrievedUrl, null, "unreachable", "Discarded after matching to a JavaScript-using domain, other than.", null);
 			return true;
 		}
-		else if ( lowerCaseUrl.contains("sciencedirect.com") ) {	// These urls are in JavaScript, having dynamic links which we cannot currently retrieve.
+		/*else if ( lowerCaseUrl.contains("sciencedirect.com") ) {	// These urls are in JavaScript, having dynamic links which we cannot currently retrieve.
 			UrlUtils.sciencedirectUrls ++;
 			UrlUtils.logQuadruple(urlId, retrievedUrl, null, "unreachable", "Discarded after matching to the JavaScript-using domain 'sciencedirect.com'.", null);
 			return true;
-		}
-		else if ( lowerCaseUrl.contains("elsevier.com") ) {	// The plain "elsevier.com" and the "journals.elsevier.com" don't give docUrls.
+		}*/
+		else if ( lowerCaseUrl.contains("www.elsevier.com") ) {	// The plain "elsevier.com" and the "journals.elsevier.com" don't give docUrls.
 			// The "linkinghub.elsevier.com" is redirecting to "sciencedirect.com".
 			// Note that we still accept the "elsevier.es" pageUrls, which give docUrls.
 			UrlUtils.elsevierUnwantedUrls ++;
@@ -371,7 +371,7 @@ public class UrlUtils
 			return true;
 		}
 		else if ( lowerCaseUrl.contains("/view/") || lowerCaseUrl.contains("scielosp.org") || lowerCaseUrl.contains("dk.um.si") || lowerCaseUrl.contains("apospublications.com")
-				|| lowerCaseUrl.contains("jorr.org") || lowerCaseUrl.contains("redalyc.org") ) {	// Avoid crawling pages with larger depth.
+				|| lowerCaseUrl.contains("jorr.org") || lowerCaseUrl.contains("redalyc.org") ) {	// Avoid crawling pages with larger depth (innerPagesToDocUrls or Previews of docUrls).
 			UrlUtils.pagesWithLargerCrawlingDepth ++;
 			UrlUtils.logQuadruple(urlId, retrievedUrl, null, "unreachable", "Discarded after matching to an increasedCrawlingDepth-site.", null);
 			return true;
@@ -396,12 +396,12 @@ public class UrlUtils
 			UrlUtils.logQuadruple(urlId, retrievedUrl, null, "unreachable", "It was discarded after participating in a 'sharedSiteSession-redirectionPack'.", null);
 			return false;	// Do not visit it.
 		}
-		else if ( UrlUtils.DOI_ORG_J_FILTER.matcher(lowerCaseUrl).matches() || UrlUtils.DOI_ORG_PARENTHESIS_FILTER.matcher(lowerCaseUrl).matches()
+		/*else if ( UrlUtils.DOI_ORG_J_FILTER.matcher(lowerCaseUrl).matches() || UrlUtils.DOI_ORG_PARENTHESIS_FILTER.matcher(lowerCaseUrl).matches()
 				|| UrlUtils.DOI_ORG_JTO_FILTER.matcher(lowerCaseUrl).matches() ) {
 			UrlUtils.doiOrgToScienceDirect ++;
 			UrlUtils.logQuadruple(urlId, retrievedUrl, null, "unreachable", "Discarded after matching to a urlType of 'doi.org', which redirects to 'sciencedirect.com'.", null);
 			return true;
-		}
+		}*/
 		else if ( shouldNotAcceptPageUrl(retrievedUrl, lowerCaseUrl) ) {
 			UrlUtils.urlsWithUnwantedForm ++;
 			UrlUtils.logQuadruple(urlId, retrievedUrl, null, "unreachable", "Discarded after matching to unwantedType-regex-rules.", null);
@@ -626,7 +626,6 @@ public class UrlUtils
 		
 		return pathStr;
 	}
-	
 	
 	
 	/**


### PR DESCRIPTION
- Retrieve the docUrls from the JavaScript-powered "sciencedirect.com"-family-urls.
- Introduce the new "HttpUtils.handleConnection()" which is used in multiple cases.
- Comment-out "sciencedirect.com"-family blocking-rules.
- Increase "FileUtils.maxStoringWaitingTime" (although irrelevant to the "sciencedirect.com").